### PR TITLE
clear the fail timeout on pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-verify-app",
   "description": "Verifies an application listens on a port when spawned",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/bevacqua/grunt-verify-app",
   "author": {
     "name": "Nicolas Bevacqua",

--- a/tasks/verify_app.js
+++ b/tasks/verify_app.js
@@ -28,19 +28,23 @@ module.exports = function(grunt) {
         var done = this.async();
         var env = _.clone(process.env);
         env.port = options.port;
+        var timer = null;
 
         console.log('[verify_app] Spawning node process to listen on port %s...', options.port);
 
         var app = spawn('node', [options.script], { stdio: 'inherit', env: env });
 
         watcher.on('listen', function (pid) {
+            if (timer !== null) {
+                clearTimeout(timer);
+            }
             kill();
             console.log('[verify_app] Detected process %s listening on port %s.', pid, options.port);
             done();
         });
 
         if (options.timeout) {
-            setTimeout(function () {
+            timer = setTimeout(function () {
                 kill();
                 grunt.fatal('[verify_app] Timed out.');
             }, options.timeout);


### PR DESCRIPTION
This keeps track of the timeout timer and clears is on pass. This allows for grunt files with long tasks occurring after the verify-app task.
