### PR TITLE
Made the grunt peer dependency less strict so that it works with newer versions of grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash": "~2.4.1"
   },
   "peerDependencies": {
-    "grunt": "0.4.2"
+    "grunt": "~0.4.2"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
The peer dependency also now matches the dev dependency.
Without this, grunt-verify-app cannot be used with grunt > 0.4.2.
